### PR TITLE
Add RaisePropertyChanged for TotalSum of Basket

### DIFF
--- a/wpf/9020-register/readme.md
+++ b/wpf/9020-register/readme.md
@@ -535,6 +535,7 @@ Now we have to implement the logic in our view model.
             // Product already in the basket -> add amount and total price
             basketItem.Amount++;
             basketItem.TotalPrice += product.UnitPrice;
+            RaisePropertyChanged(nameof(TotalSum));
         }
         else
         {


### PR DESCRIPTION
Whenever an item is added twice in a row, the TotalSum only refreshes after another item gets clicked.

For some reason the "ObservableCollection.CollectionChanged()" method does not recognize that the basket item has changed.